### PR TITLE
Update price_discount_per_quantity to be more flexible.

### DIFF
--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -39,7 +39,7 @@ class Promotion
   def price_discount_per_quantity(cart_items)
     matching_items = cart_items.select { |item| item.product_code == @product_code }
 
-    matching_items.each { |item| item.price = @discount } if matching_items.length >= 3
+    matching_items.each { |item| item.price = @discount } if matching_items.length >= @min_quantity
   end
 
   def percentage_discount_per_quantity(cart_items)

--- a/spec/promotion_spec.rb
+++ b/spec/promotion_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/promotion'
 RSpec.describe Promotion do
   let(:buy_one_get_one_free_promotion) { Promotion.new({ title:'Grean Tea - Buy one and get one free!', product_code: "GR1", type: :buy_x_get_x_free, discount: 100, min_quantity: 1, free_quantity: 1 }) }
   let(:buy_3_get_2_free_promotion) { Promotion.new({ title:'Grean Tea - Buy 3 and get 2 free!', product_code: "GR1", type: :buy_x_get_x_free, discount: 100, min_quantity: 3, free_quantity: 2 }) }
-  let(:price_discount_per_quantity_promotion) { Promotion.new({ title:'Strawberries - Buy 3 or more and get price reduction to 4.50$!', product_code: "SR1", type: :price_discount_per_quantity, discount: 4.50 }) }
+  let(:price_discount_per_quantity_promotion) { Promotion.new({ title:'Strawberries - Buy 3 or more and get price reduction to 4.50$!', product_code: "SR1", type: :price_discount_per_quantity, discount: 4.50, min_quantity: 3 }) }
   let(:percentage_discount_per_quantity_promotion) { Promotion.new({ title:'Coffee - Buy 3 or more and get price reduction 2/3 of the price!', product_code: "CF1", type: :percentage_discount_per_quantity, discount: 66.6 }) }
   let(:promotions) { [buy_one_get_one_free_promotion, price_discount_per_quantity_promotion, percentage_discount_per_quantity_promotion,buy_3_get_2_free_promotion] }
   let(:item1) { Item.new('Green Tea', 'GR1', 3.50) }
@@ -85,15 +85,17 @@ RSpec.describe Promotion do
         cart.add_item(item1)
         cart.add_item(item2)
         cart.add_item(item2)
+        cart.add_item(item2)
         price_discount_per_quantity_promotion.apply(cart.items)
 
         expect(cart.items[0].price).to eq(4.50)
         expect(cart.items[1].price).to eq(3.50)
         expect(cart.items[2].price).to eq(4.50)
         expect(cart.items[3].price).to eq(4.50)
+        expect(cart.items[4].price).to eq(4.50)
       end
 
-      it "does not apply promotion if quantity is bellow 3" do
+      it "does not apply promotion if quantity is bellow min_quantity" do
         cart.add_item(item2)
         cart.add_item(item2)
 


### PR DESCRIPTION
- Add a min_quantity to price_discount_per_quantity_promotion in the promotion_rspec file, this ensure the method is flexible and can get a flexible quantity instead of a fixed number.
- Update price_discount_per_quantity to use the min_quantity instance variable instead of a fixed number, this make the method more flexible and scalable.